### PR TITLE
Add popups for success or error notification after create update delete

### DIFF
--- a/src/app/root/store/effects/application.effects.ts
+++ b/src/app/root/store/effects/application.effects.ts
@@ -5,6 +5,8 @@ import { of } from 'rxjs';
 import { ApiService } from '../../../shared/modules/api/api.service';
 import * as applicationActions from '../actions/application.action';
 import * as serviceActions from '../actions/service.actions';
+import { NotificationType } from '../../interfaces/notification';
+import { NotificationService } from '../../../shared/modules/notification/notification.service';
 
 @Injectable()
 export class ApplicationEffects {
@@ -25,8 +27,17 @@ export class ApplicationEffects {
             ofType(applicationActions.deleteApplication),
             switchMap(({ application }) =>
                 this.apiService.deleteApplication(application).pipe(
-                    map(() => applicationActions.deleteApplicationSuccess({ application })),
-                    catchError((error) => of(applicationActions.deleteApplicationError({ error: error.message }))),
+                    map(() => {
+                        this.notifyService.notify(
+                            NotificationType.success,
+                            `Application ${application.application_name} deleted successfully!`,
+                        );
+                        return applicationActions.deleteApplicationSuccess({ application });
+                    }),
+                    catchError((error) => {
+                        this.notifyService.notify(NotificationType.error, 'Application deletion failed');
+                        return of(applicationActions.deleteApplicationError({ error: error.message }));
+                    }),
                 ),
             ),
         ),
@@ -38,8 +49,17 @@ export class ApplicationEffects {
             switchMap(({ application }) =>
                 this.apiService.addApplication(application).pipe(
                     // TODO Get the app form the api and store it with the id
-                    map(() => applicationActions.postApplicationSuccess({ application })),
-                    catchError((error) => of(applicationActions.postApplicationError({ error: error.message }))),
+                    map(() => {
+                        this.notifyService.notify(
+                            NotificationType.success,
+                            `Application ${application.application_name} created successfully!`,
+                        );
+                        return applicationActions.postApplicationSuccess({ application });
+                    }),
+                    catchError((error) => {
+                        this.notifyService.notify(NotificationType.error, 'Application creation failed');
+                        return of(applicationActions.postApplicationError({ error: error.message }));
+                    }),
                 ),
             ),
         ),
@@ -50,8 +70,17 @@ export class ApplicationEffects {
             ofType(applicationActions.updateApplication),
             switchMap(({ application }) =>
                 this.apiService.updateApplication(application).pipe(
-                    map(() => applicationActions.updateApplicationSuccess({ application })),
-                    catchError((error) => of(applicationActions.updateApplicationError({ error: error.message }))),
+                    map(() => {
+                        this.notifyService.notify(
+                            NotificationType.success,
+                            `Application ${application.application_name} modified successfully!`,
+                        );
+                        return applicationActions.updateApplicationSuccess({ application });
+                    }),
+                    catchError((error) => {
+                        this.notifyService.notify(NotificationType.error, 'Application modification failed');
+                        return of(applicationActions.updateApplicationError({ error: error.message }));
+                    }),
                 ),
             ),
         ),
@@ -69,5 +98,9 @@ export class ApplicationEffects {
         ),
     );
 
-    constructor(private actions$: Actions, private apiService: ApiService) {}
+    constructor(
+        private actions$: Actions,
+        private apiService: ApiService,
+        private notifyService: NotificationService,
+    ) {}
 }

--- a/src/app/root/store/effects/organization.effects.ts
+++ b/src/app/root/store/effects/organization.effects.ts
@@ -4,6 +4,8 @@ import { catchError, map, switchMap } from 'rxjs/operators';
 import { of } from 'rxjs';
 import { ApiService } from '../../../shared/modules/api/api.service';
 import * as organizationActions from '../actions/organization.action';
+import { NotificationType } from '../../interfaces/notification';
+import { NotificationService } from '../../../shared/modules/notification/notification.service';
 
 @Injectable()
 export class OrganizationEffects {
@@ -24,8 +26,17 @@ export class OrganizationEffects {
             ofType(organizationActions.deleteOrganization),
             switchMap(({ organization }) =>
                 this.apiService.deleteOrganization(organization).pipe(
-                    map(() => organizationActions.deleteOrganizationSuccess({ organization })),
-                    catchError((error) => of(organizationActions.deleteOrganizationError({ error: error.message }))),
+                    map(() => {
+                        this.notifyService.notify(
+                            NotificationType.success,
+                            `Organization ${organization.name} deleted successfully!`,
+                        );
+                        return organizationActions.deleteOrganizationSuccess({ organization });
+                    }),
+                    catchError((error) => {
+                        this.notifyService.notify(NotificationType.error, 'Organization deletion failed');
+                        return of(organizationActions.deleteOrganizationError({ error: error.message }));
+                    }),
                 ),
             ),
         ),
@@ -36,8 +47,17 @@ export class OrganizationEffects {
             ofType(organizationActions.postOrganization),
             switchMap(({ organization }) =>
                 this.apiService.addOrganization(organization).pipe(
-                    map((id: string) => organizationActions.postOrganizationSuccess({ organization, id })),
-                    catchError((error) => of(organizationActions.postOrganizationError({ error: error.message }))),
+                    map((id: string) => {
+                        this.notifyService.notify(
+                            NotificationType.success,
+                            `Organization ${organization.name} created successfully!`,
+                        );
+                        return organizationActions.postOrganizationSuccess({ organization, id });
+                    }),
+                    catchError((error) => {
+                        this.notifyService.notify(NotificationType.error, 'Organization creation failed');
+                        return of(organizationActions.postOrganizationError({ error: error.message }));
+                    }),
                 ),
             ),
         ),
@@ -48,12 +68,25 @@ export class OrganizationEffects {
             ofType(organizationActions.updateOrganization),
             switchMap(({ organization }) =>
                 this.apiService.updateOrganization(organization).pipe(
-                    map(() => organizationActions.updateOrganizationSuccess({ organization })),
-                    catchError((error) => of(organizationActions.updateOrganizationError({ error: error.message }))),
+                    map(() => {
+                        this.notifyService.notify(
+                            NotificationType.success,
+                            `Organization ${organization.name} modified successfully!`,
+                        );
+                        return organizationActions.updateOrganizationSuccess({ organization });
+                    }),
+                    catchError((error) => {
+                        this.notifyService.notify(NotificationType.error, 'Organization modification failed');
+                        return of(organizationActions.updateOrganizationError({ error: error.message }));
+                    }),
                 ),
             ),
         ),
     );
 
-    constructor(private actions$: Actions, private apiService: ApiService) {}
+    constructor(
+        private actions$: Actions,
+        private apiService: ApiService,
+        private notifyService: NotificationService,
+    ) {}
 }

--- a/src/app/root/store/effects/service.effects.ts
+++ b/src/app/root/store/effects/service.effects.ts
@@ -39,7 +39,10 @@ export class ServiceEffects {
             ofType(serviceActions.postService),
             mergeMap(({ service }) =>
                 this.apiService.addService(service).pipe(
-                    map((serviceId) => serviceActions.postServiceSuccess({ service, serviceId })),
+                    map((serviceId) => {
+                        this.notifyService.notify(NotificationType.success, 'Service created successfully!');
+                        return serviceActions.postServiceSuccess({ service, serviceId });
+                    }),
                     tap(() => this.router.navigate(['/control'])),
                     catchError((error) => {
                         this.notifyService.notify(NotificationType.error, 'File was not in the correct format');
@@ -55,8 +58,17 @@ export class ServiceEffects {
             ofType(serviceActions.deleteService),
             switchMap(({ service }) =>
                 this.apiService.deleteService(service).pipe(
-                    map(() => serviceActions.deleteServiceSuccess({ service })),
-                    catchError((error) => of(serviceActions.deleteServiceError({ error: error.message }))),
+                    map(() => {
+                        this.notifyService.notify(
+                            NotificationType.success,
+                            `Service ${service.microservice_name} deleted successfully!`,
+                        );
+                        return serviceActions.deleteServiceSuccess({ service });
+                    }),
+                    catchError((error) => {
+                        this.notifyService.notify(NotificationType.error, 'Service deletion failed');
+                        return of(serviceActions.deleteServiceError({ error: error.message }));
+                    }),
                 ),
             ),
         ),
@@ -67,8 +79,17 @@ export class ServiceEffects {
             ofType(serviceActions.updateService),
             switchMap(({ service }) =>
                 this.apiService.updateService(service, service._id.$oid).pipe(
-                    map((service) => serviceActions.updateServiceSuccess({ service })),
-                    catchError((error) => of(serviceActions.updateServiceError({ error: error.message }))),
+                    map((service) => {
+                        this.notifyService.notify(
+                            NotificationType.success,
+                            `Service ${service.microservice_name} modified successfully!`,
+                        );
+                        return serviceActions.updateServiceSuccess({ service });
+                    }),
+                    catchError((error) => {
+                        this.notifyService.notify(NotificationType.error, 'Service modification failed');
+                        return of(serviceActions.updateServiceError({ error: error.message }));
+                    }),
                 ),
             ),
         ),

--- a/src/app/root/store/effects/user.effects.ts
+++ b/src/app/root/store/effects/user.effects.ts
@@ -27,7 +27,7 @@ export class UserEffects {
             switchMap(({ user }) =>
                 this.apiService.registerUser(user).pipe(
                     map((newUser) => {
-                        this.notifyService.notify(NotificationType.error, `User ${newUser.name} created successfully!`);
+                        this.notifyService.notify(NotificationType.success, `User ${user.name} created successfully!`);
                         return userActions.postUserSuccess({ user: newUser });
                     }),
                     catchError((error) => {
@@ -44,8 +44,14 @@ export class UserEffects {
             ofType(userActions.updateUser),
             switchMap(({ user }) =>
                 this.apiService.updateUser(user).pipe(
-                    map(() => userActions.updateUserSuccess({ user })),
-                    catchError((error) => of(userActions.updateUserError({ error: error.message }))),
+                    map(() => {
+                        this.notifyService.notify(NotificationType.success, `User ${user.name} modified successfully!`);
+                        return userActions.updateUserSuccess({ user });
+                    }),
+                    catchError((error) => {
+                        this.notifyService.notify(NotificationType.error, 'User modification failed');
+                        return of(userActions.updateUserError({ error: error.message }));
+                    }),
                 ),
             ),
         ),
@@ -56,8 +62,14 @@ export class UserEffects {
             ofType(userActions.deleteUser),
             switchMap(({ user }) =>
                 this.apiService.deleteUser(user).pipe(
-                    map(() => userActions.deleteUserSuccess({ user })),
-                    catchError((error) => of(userActions.deleteUserError({ error: error.message }))),
+                    map(() => {
+                        this.notifyService.notify(NotificationType.success, `User ${user.name} deleted successfully!`);
+                        return userActions.deleteUserSuccess({ user });
+                    }),
+                    catchError((error) => {
+                        this.notifyService.notify(NotificationType.error, 'User deletion failed');
+                        return of(userActions.deleteUserError({ error: error.message }));
+                    }),
                 ),
             ),
         ),

--- a/src/app/shared/modules/notification/notification.component.ts
+++ b/src/app/shared/modules/notification/notification.component.ts
@@ -6,9 +6,9 @@ import { NotificationService } from './notification.service';
     selector: 'app-notification',
     template: `
         <div class="center">
-            <mat-icon *ngIf="type === Type.error">error</mat-icon>
-            <mat-icon *ngIf="type === Type.information">info</mat-icon>
-            <mat-icon *ngIf="type === Type.success">check_circle</mat-icon>
+            <mat-icon class="notification-icon" *ngIf="type === Type.error">error</mat-icon>
+            <mat-icon class="notification-icon" *ngIf="type === Type.information">info</mat-icon>
+            <mat-icon class="notification-icon" *ngIf="type === Type.success">check_circle</mat-icon>
             <p class="addButtonDiv">{{ massage }}</p>
         </div>
     `,
@@ -22,6 +22,10 @@ import { NotificationService } from './notification.service';
                 display: inline-block;
                 vertical-align: middle;
                 text-align: center;
+            }
+
+            .notification-icon {
+                margin-right: 7px;
             }
         `,
     ],

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -141,11 +141,11 @@ text.id {
 }
 
 .error-snackbar {
-    background-color: #a31919;
+    --mdc-snackbar-container-color: #a31919;
 }
 
 .success-snackbar {
-    background-color: #28a513;
+    --mdc-snackbar-container-color: #28a513;
 }
 
 mat-card {


### PR DESCRIPTION
PR for [Display success or error notification after create, update, delete of something. #13](https://github.com/oakestra/dashboard/issues/13)
Fixes #13 

**Changes:**
- Visually enhanced the popup by adding a small space after the mat-icon and ensuring the coloring classes work (since Angular >= v15, [see this](https://stackoverflow.com/questions/47560696/angular-5-and-material-how-to-change-the-background-color-from-snackbar-compon))
- Added popups for user creation, deletion, modification
- Added popups for service creation, deletion, modification
- Added popups for application creation, deletion, modification
- Added popups for organization creation, deletion, modification

**Note:** I've added calls to the `notificationService` in the `.effects.ts` files, since I saw that this is the good practice while working with ngrx, and this was also the precedent approach in the codebase. But let me know if you prefer these invocations in the components code directly, or elsewhere.

![image](https://github.com/oakestra/dashboard/assets/30694576/199646e1-4bfa-4401-9af2-8c501d523e5f)