### PR TITLE
added service log box

### DIFF
--- a/src/app/control/dev-home/dev-home.component.scss
+++ b/src/app/control/dev-home/dev-home.component.scss
@@ -169,3 +169,10 @@ mat-card p {
 .servicesList {
     padding: 10px;
 }
+
+code-logs {
+    font-family: monospace; /* Use a monospace font for code readability */
+    overflow-y: auto; /* Enable vertical scrolling */
+    padding: 10px;
+    border: 1px solid #ccc;
+}

--- a/src/app/control/dev-home/dialogs/service-status/dialog-service-status.html
+++ b/src/app/control/dev-home/dialogs/service-status/dialog-service-status.html
@@ -10,6 +10,8 @@
             <p><b>Disk:</b> {{(instance | async).disk}}</p>
             <p><b>Cluster:</b> {{(instance | async).cluster_id}}</p>
             <p><b>Node IP:</b> {{(instance | async).publicip}}</p>
+            <p><b>Logs:</b></p>
+            <textarea class="code-logs" rows="10" cols="100" disabled> {{(instance | async).logs}} </textarea>
         </div>
     </div>
 </mat-dialog-content>

--- a/src/app/root/interfaces/instance.ts
+++ b/src/app/root/interfaces/instance.ts
@@ -14,6 +14,7 @@ export interface IInstance {
     addresses: IAddresses;
     status_detail: string;
     instance_number: number;
+    logs: string;
 }
 
 export interface IHistoricalData {


### PR DESCRIPTION
# What's new?

<img width="1012" alt="Screenshot 2023-12-20 at 15 54 18" src="https://github.com/oakestra/dashboard/assets/25887329/13cb58f4-ac0f-4d66-81b1-170ddc27a981">

The new log box shows the latest 1024 bytes of logs of each service. 