### PR TITLE
Support for v2 SLA Upload & JSON Editor

### DIFF
--- a/src/app/control/sla-form/components/file-upload/file-upload.component.html
+++ b/src/app/control/sla-form/components/file-upload/file-upload.component.html
@@ -1,4 +1,4 @@
-<div (click)="fileUpload.click()" class="content">
+<div class="content">
     {{ filename }}
     <div class="sample-code">
         <p>The file can be a full SLA descriptor (CLI/API standard) or a microservice list.</p>
@@ -10,6 +10,9 @@
     <div class="file-upload">
         <input #fileUpload (change)="loadFile($event)" accept="application/JSON" class="file-input" type="file" />
     </div>
+    <button (click)="fileUpload.click()" nbButton status="info" type="button" style="margin-right: 10px">
+        Select File
+    </button>
     <button (click)="uploadDocument()" [disabled]="file === undefined" color="primary" nbButton type="button">
         Upload Config
     </button>

--- a/src/app/control/sla-form/components/file-upload/file-upload.component.html
+++ b/src/app/control/sla-form/components/file-upload/file-upload.component.html
@@ -1,20 +1,22 @@
-<div class="content">
-    {{ filename }}
-    <div class="sample-code">
-        <p>The file can be a full SLA descriptor (CLI/API standard) or a microservice list.</p>
-        <pre>{{ sampleService | json }}</pre>
+<div class="upload-container">
+    <div class="filename-header">
+        {{ filename }}
     </div>
-</div>
 
-<div class="file-upload-div">
-    <div class="file-upload">
-        <input #fileUpload (change)="loadFile($event)" accept="application/JSON" class="file-input" type="file" />
+    <div class="editor-area">
+        <p>The file can be a full SLA descriptor (CLI/API standard) or a microservice list. Also it can be edited before uploading.</p>
+        <textarea [(ngModel)]="jsonContent" nbInput fullWidth rows="20"></textarea>
     </div>
-    <button (click)="fileUpload.click()" nbButton status="info" type="button" style="margin-right: 10px">
-        Select File
-    </button>
-    <button (click)="uploadDocument()" [disabled]="file === undefined" color="primary" nbButton type="button">
-        Upload Config
-    </button>
-    <p>Supported formats: CLI/API SLA (v2.0) or legacy microservice array.</p>
+
+    <div class="actions-area">
+        <input #fileUpload (change)="loadFile($event)" accept="application/JSON" class="file-input" type="file" />
+
+        <button (click)="fileUpload.click()" nbButton status="info" type="button">Select File</button>
+
+        <button (click)="uploadDocument()" [disabled]="!jsonContent" color="primary" nbButton type="button">
+            Upload Config
+        </button>
+
+        <p>Supported formats: CLI/API SLA (v2.0) or legacy microservice array.</p>
+    </div>
 </div>

--- a/src/app/control/sla-form/components/file-upload/file-upload.component.html
+++ b/src/app/control/sla-form/components/file-upload/file-upload.component.html
@@ -1,7 +1,7 @@
 <div (click)="fileUpload.click()" class="content">
     {{ filename }}
     <div class="sample-code">
-        <p>The file must be formatted as follows:</p>
+        <p>The file can be a full SLA descriptor (CLI/API standard) or a microservice list.</p>
         <pre>{{ sampleService | json }}</pre>
     </div>
 </div>
@@ -13,5 +13,5 @@
     <button (click)="uploadDocument()" [disabled]="file === undefined" color="primary" nbButton type="button">
         Upload Config
     </button>
-    <p>The file should contain only the microservice array</p>
+    <p>Supported formats: CLI/API SLA (v2.0) or legacy microservice array.</p>
 </div>

--- a/src/app/control/sla-form/components/file-upload/file-upload.component.scss
+++ b/src/app/control/sla-form/components/file-upload/file-upload.component.scss
@@ -1,35 +1,43 @@
-.content {
-    height: 50vh;
+.upload-container {
+    padding: 2rem;
     display: flex;
-    justify-content: center;
     flex-direction: column;
     align-items: center;
-    font-size: 2rem;
-    color: lightgray;
-    padding-top: 20px;
 
-    .sample-code {
-        padding-top: 40px;
-        display: flex;
-        flex-direction: column;
+    .filename-header {
         font-size: 1.5rem;
+        color: lightgray;
+        margin-bottom: 1rem;
+    }
 
-        pre,
+    .editor-area {
+        width: 100%;
+        margin-bottom: 2rem;
+
         p {
-            font-size: 1rem;
             color: lightgray;
+            margin-bottom: 0.5rem;
+        }
+
+        textarea {
+            font-family: monospace;
         }
     }
-}
 
-.file-upload-div {
-    text-align: center;
+    .actions-area {
+        text-align: center;
 
-    .file-upload {
-        display: none;
-    }
+        .file-input {
+            display: none;
+        }
 
-    button {
-        margin-bottom: 10px;
+        button {
+            margin-right: 1rem;
+        }
+
+        p {
+            color: lightgray;
+            margin-top: 1rem;
+        }
     }
 }

--- a/src/app/control/sla-form/components/file-upload/file-upload.component.ts
+++ b/src/app/control/sla-form/components/file-upload/file-upload.component.ts
@@ -15,7 +15,7 @@ export class FileUploadComponent extends SubComponent {
     @Input() service: IService;
     @Input() applicationName: string;
 
-    file: File | undefined;
+    jsonContent = '';
     filename = 'Select File to Upload';
 
     sampleService: any = {
@@ -33,32 +33,31 @@ export class FileUploadComponent extends SubComponent {
         private notifyService: NotificationService,
     ) {
         super();
+        this.jsonContent = JSON.stringify(this.sampleService, null, 4);
     }
 
     loadFile(event: any) {
-        this.file = event.target.files[0] as File;
-        console.log(this.file);
-        this.filename = this.file.name;
+        const file = event.target.files[0] as File;
+        console.log(file);
+        if (file) {
+            this.filename = file.name;
+            const fileReader = new FileReader();
+            fileReader.onload = () => {
+                this.jsonContent = (fileReader.result ?? '').toString();
+            };
+            fileReader.readAsText(file);
+        }
     }
 
     uploadDocument() {
-        if (this.file) {
-            const fileReader = new FileReader();
-            fileReader.onload = () => {
-                try {
-                    const rawJson = JSON.parse((fileReader.result ?? '').toString());
-
-                   
-                    const result = this.slaParser.parse(rawJson, this.applicationName);
-
-                    console.log(result);
-                    this.upload.emit(result);
-                } catch (error) {
-                    console.error(error);
-                    this.notifyService.notify(NotificationType.error, (error as any).message || 'Error parsing SLA file');
-                }
-            };
-            fileReader.readAsText(this.file);
+        try {
+            const rawJson = JSON.parse(this.jsonContent);
+            const result = this.slaParser.parse(rawJson, this.applicationName);
+            console.log(result);
+            this.upload.emit(result);
+        } catch (error) {
+            console.error(error);
+            this.notifyService.notify(NotificationType.error, (error as any).message || 'Error parsing SLA content');
         }
     }
 

--- a/src/app/control/sla-form/components/file-upload/file-upload.component.ts
+++ b/src/app/control/sla-form/components/file-upload/file-upload.component.ts
@@ -1,6 +1,9 @@
 import { Component, EventEmitter, Input, Output } from '@angular/core';
 import { SubComponent } from '../../../../root/classes/subComponent';
 import { IService } from '../../../../root/interfaces/service';
+import { ParsedSlaResult, SlaParserService } from '../../../../shared/modules/helper/sla-parser.service';
+import { NotificationService } from '../../../../shared/modules/notification/notification.service';
+import { NotificationType } from '../../../../root/interfaces/notification';
 
 @Component({
     selector: 'form-file-upload',
@@ -8,14 +11,29 @@ import { IService } from '../../../../root/interfaces/service';
     styleUrls: ['./file-upload.component.scss'],
 })
 export class FileUploadComponent extends SubComponent {
-    @Output() upload = new EventEmitter<IService[]>();
+    @Output() upload = new EventEmitter<ParsedSlaResult>();
     @Input() service: IService;
+    @Input() applicationName: string;
+
     file: File | undefined;
     filename = 'Select File to Upload';
 
     sampleService: any = {
-        microservices: [{ microservice_name: 'name', microservice_namespace: 'namespace', '...': '...' }],
+        sla_version: 'v2.0',
+        applications: [
+            {
+                application_name: 'myapp',
+                microservices: [{ microservice_name: 'name', '...': '...' }],
+            },
+        ],
     };
+
+    constructor(
+        private slaParser: SlaParserService,
+        private notifyService: NotificationService,
+    ) {
+        super();
+    }
 
     loadFile(event: any) {
         this.file = event.target.files[0] as File;
@@ -27,9 +45,18 @@ export class FileUploadComponent extends SubComponent {
         if (this.file) {
             const fileReader = new FileReader();
             fileReader.onload = () => {
-                const sla = JSON.parse((fileReader.result ?? '').toString());
-                console.log(sla);
-                this.upload.emit(sla.microservices as IService[]);
+                try {
+                    const rawJson = JSON.parse((fileReader.result ?? '').toString());
+
+                   
+                    const result = this.slaParser.parse(rawJson, this.applicationName);
+
+                    console.log(result);
+                    this.upload.emit(result);
+                } catch (error) {
+                    console.error(error);
+                    this.notifyService.notify(NotificationType.error, (error as any).message || 'Error parsing SLA file');
+                }
             };
             fileReader.readAsText(this.file);
         }

--- a/src/app/control/sla-form/sla-form.component.html
+++ b/src/app/control/sla-form/sla-form.component.html
@@ -23,7 +23,10 @@
             </nb-tab>
 
             <nb-tab tabTitle="SLA">
-                <form-file-upload (upload)="slaFromFile($event)"></form-file-upload>
+                <form-file-upload
+                    [applicationName]="currentApplication?.application_name"
+                    (upload)="slaFromFile($event)"
+                ></form-file-upload>
             </nb-tab>
         </nb-tabset>
     </nb-card-body>

--- a/src/app/control/sla-form/sla-form.component.ts
+++ b/src/app/control/sla-form/sla-form.component.ts
@@ -5,6 +5,7 @@ import { Observable } from 'rxjs';
 import { ApiService } from '../../shared/modules/api/api.service';
 import { NotificationService } from '../../shared/modules/notification/notification.service';
 import { NotificationType } from '../../root/interfaces/notification';
+import { UserService } from '../../shared/modules/auth/user.service';
 import { IApplication } from '../../root/interfaces/application';
 import { IService } from '../../root/interfaces/service';
 import { appReducer, postService, updateServiceSuccess } from '../../root/store';
@@ -58,6 +59,7 @@ export class SlaFormComponent implements OnInit {
         private store: Store<appReducer.AppState>,
         private slaGenerator: SlaGeneratorService,
         private serviceGenerator: ServiceGeneratorService,
+        private userService: UserService,
     ) {
         this.app$.subscribe((app) => {
             console.log(app);
@@ -103,7 +105,36 @@ export class SlaFormComponent implements OnInit {
 
     slaFromFile(result: ParsedSlaResult) {
         if (result.type === 'v2') {
-            this.addService(result.data);
+            const data = result.data;
+            // Auto-fill IDs if missing and context is available
+            if (this.currentApplication && this.currentUser) {
+                const org = this.userService.getOrganization();
+                const customer = org === 'root' ? this.currentUser._id.$oid : org;
+
+                if (!data.customerID) {
+                    data.customerID = customer;
+                } else if (data.customerID !== customer) {
+                    this.notifyService.notify(
+                        NotificationType.error,
+                        `SLA Error: File customerID "${data.customerID}" does not match current user "${customer}".`,
+                    );
+                    return;
+                }
+
+                if (data.applications && data.applications.length > 0) {
+                    const app = data.applications[0];
+                    if (!app.applicationID) {
+                        app.applicationID = this.currentApplication._id.$oid;
+                    } else if (app.applicationID !== this.currentApplication._id.$oid) {
+                        this.notifyService.notify(
+                            NotificationType.error,
+                            `SLA Error: File applicationID "${app.applicationID}" does not match current application "${this.currentApplication._id.$oid}".`,
+                        );
+                        return;
+                    }
+                }
+            }
+            this.addService(data);
         } else if (result.type === 'v1_microservices') {
             if (!this.currentApplication) {
                 this.notifyService.notify(NotificationType.error, 'No application selected. Cannot generate SLA from legacy format.');

--- a/src/app/control/sla-form/sla-form.component.ts
+++ b/src/app/control/sla-form/sla-form.component.ts
@@ -4,12 +4,14 @@ import { select, Store } from '@ngrx/store';
 import { Observable } from 'rxjs';
 import { ApiService } from '../../shared/modules/api/api.service';
 import { NotificationService } from '../../shared/modules/notification/notification.service';
+import { NotificationType } from '../../root/interfaces/notification';
 import { IApplication } from '../../root/interfaces/application';
 import { IService } from '../../root/interfaces/service';
 import { appReducer, postService, updateServiceSuccess } from '../../root/store';
 import { selectCurrentApplication } from '../../root/store/selectors/application.selector';
 import { SlaGeneratorService } from '../../shared/modules/helper/sla-generator.service';
 import { ServiceGeneratorService } from '../../shared/modules/helper/service-generator.service';
+import { ParsedSlaResult } from '../../shared/modules/helper/sla-parser.service';
 import { IUser } from '../../root/interfaces/user';
 import { selectCurrentUser } from '../../root/store/selectors/user.selector';
 import { selectCurrentServices } from '../../root/store/selectors/service.selector';
@@ -99,12 +101,25 @@ export class SlaFormComponent implements OnInit {
         }
     }
 
-    slaFromFile(microservices: IService[]) {
-        microservices.map((service) => {
-            console.log(service);
-            const sla = this.slaGenerator.generateSLA(service, this.currentApplication, this.currentUser);
-            this.addService(sla);
-        });
+    slaFromFile(result: ParsedSlaResult) {
+        if (result.type === 'v2') {
+            this.addService(result.data);
+        } else if (result.type === 'v1_microservices') {
+            if (!this.currentApplication) {
+                this.notifyService.notify(NotificationType.error, 'No application selected. Cannot generate SLA from legacy format.');
+                return;
+            }
+            if (!this.currentUser) {
+                this.notifyService.notify(NotificationType.error, 'User session not loaded. Please try again.');
+                return;
+            }
+            const microservices = result.data as IService[];
+            microservices.forEach((service) => {
+                console.log(service);
+                const sla = this.slaGenerator.generateSLA(service, this.currentApplication, this.currentUser);
+                this.addService(sla);
+            });
+        }
     }
 
     updateService(sla: any) {

--- a/src/app/control/sla-form/sla-form.component.ts
+++ b/src/app/control/sla-form/sla-form.component.ts
@@ -3,16 +3,13 @@ import { ActivatedRoute, Router } from '@angular/router';
 import { select, Store } from '@ngrx/store';
 import { Observable } from 'rxjs';
 import { ApiService } from '../../shared/modules/api/api.service';
-import { NotificationService } from '../../shared/modules/notification/notification.service';
-import { NotificationType } from '../../root/interfaces/notification';
-import { UserService } from '../../shared/modules/auth/user.service';
+import { SlaGeneratorService } from '../../shared/modules/helper/sla-generator.service';
+import { ServiceGeneratorService } from '../../shared/modules/helper/service-generator.service';
+import { ParsedSlaResult } from '../../shared/modules/helper/sla-parser.service';
 import { IApplication } from '../../root/interfaces/application';
 import { IService } from '../../root/interfaces/service';
 import { appReducer, postService, updateServiceSuccess } from '../../root/store';
 import { selectCurrentApplication } from '../../root/store/selectors/application.selector';
-import { SlaGeneratorService } from '../../shared/modules/helper/sla-generator.service';
-import { ServiceGeneratorService } from '../../shared/modules/helper/service-generator.service';
-import { ParsedSlaResult } from '../../shared/modules/helper/sla-parser.service';
 import { IUser } from '../../root/interfaces/user';
 import { selectCurrentUser } from '../../root/store/selectors/user.selector';
 import { selectCurrentServices } from '../../root/store/selectors/service.selector';
@@ -55,11 +52,9 @@ export class SlaFormComponent implements OnInit {
         private route: ActivatedRoute,
         private api: ApiService,
         private router: Router,
-        private notifyService: NotificationService,
         private store: Store<appReducer.AppState>,
         private slaGenerator: SlaGeneratorService,
         private serviceGenerator: ServiceGeneratorService,
-        private userService: UserService,
     ) {
         this.app$.subscribe((app) => {
             console.log(app);
@@ -104,52 +99,20 @@ export class SlaFormComponent implements OnInit {
     }
 
     slaFromFile(result: ParsedSlaResult) {
+        const generatedData = this.slaGenerator.validateAndGenerateFromFile(
+            result,
+            this.currentApplication,
+            this.currentUser,
+        );
+
+        if (!generatedData) {
+            return;
+        }
+
         if (result.type === 'v2') {
-            const data = result.data;
-            // Auto-fill IDs if missing and context is available
-            if (this.currentApplication && this.currentUser) {
-                const org = this.userService.getOrganization();
-                const customer = org === 'root' ? this.currentUser._id.$oid : org;
-
-                if (!data.customerID) {
-                    data.customerID = customer;
-                } else if (data.customerID !== customer) {
-                    this.notifyService.notify(
-                        NotificationType.error,
-                        `SLA Error: File customerID "${data.customerID}" does not match current user "${customer}".`,
-                    );
-                    return;
-                }
-
-                if (data.applications && data.applications.length > 0) {
-                    const app = data.applications[0];
-                    if (!app.applicationID) {
-                        app.applicationID = this.currentApplication._id.$oid;
-                    } else if (app.applicationID !== this.currentApplication._id.$oid) {
-                        this.notifyService.notify(
-                            NotificationType.error,
-                            `SLA Error: File applicationID "${app.applicationID}" does not match current application "${this.currentApplication._id.$oid}".`,
-                        );
-                        return;
-                    }
-                }
-            }
-            this.addService(data);
+            this.addService(generatedData);
         } else if (result.type === 'v1_microservices') {
-            if (!this.currentApplication) {
-                this.notifyService.notify(NotificationType.error, 'No application selected. Cannot generate SLA from legacy format.');
-                return;
-            }
-            if (!this.currentUser) {
-                this.notifyService.notify(NotificationType.error, 'User session not loaded. Please try again.');
-                return;
-            }
-            const microservices = result.data as IService[];
-            microservices.forEach((service) => {
-                console.log(service);
-                const sla = this.slaGenerator.generateSLA(service, this.currentApplication, this.currentUser);
-                this.addService(sla);
-            });
+            generatedData.forEach((sla: any) => this.addService(sla));
         }
     }
 

--- a/src/app/shared/modules/helper/sla-generator.service.ts
+++ b/src/app/shared/modules/helper/sla-generator.service.ts
@@ -4,12 +4,17 @@ import { IService } from '../../../root/interfaces/service';
 import { IApplication } from '../../../root/interfaces/application';
 import { IUser } from '../../../root/interfaces/user';
 import { UserService } from '../auth/user.service';
+import { NotificationService } from '../notification/notification.service';
+import { NotificationType } from '../../../root/interfaces/notification';
 
 @Injectable({
     providedIn: 'root',
 })
 export class SlaGeneratorService {
-    constructor(private userService: UserService) {
+    constructor(
+        private userService: UserService,
+        private notifyService: NotificationService
+    ) {
         userService.getOrganization();
     }
 
@@ -32,5 +37,68 @@ export class SlaGeneratorService {
             args: [''],
         };
         return CleanJsonService.deleteEmptyValues(sla);
+    }
+
+    public validateAndGenerateFromFile(
+        result: any,
+        currentApplication: IApplication,
+        currentUser: IUser
+    ) {
+        if (result.type === 'v2') {
+            return this.generateSLAv2(result.data, currentApplication, currentUser);
+        } else if (result.type === 'v1_microservices') {
+            if (!currentApplication) {
+                this.notifyService.notify(
+                    NotificationType.error,
+                    'No application selected. Cannot generate SLA from legacy format.'
+                );
+                return null;
+            }
+            if (!currentUser) {
+                this.notifyService.notify(
+                    NotificationType.error,
+                    'User session not loaded. Please try again.'
+                );
+                return null;
+            }
+            const microservices = result.data as IService[];
+            return microservices.map((service) =>
+                this.generateSLA(service, currentApplication, currentUser)
+            );
+        }
+        return null;
+    }
+
+    private generateSLAv2(
+        data: any,
+        currentApplication: IApplication,
+        currentUser: IUser
+    ) {
+        const org = this.userService.getOrganization();
+        const customer = org === 'root' ? currentUser._id.$oid : org;
+
+        if (!data.customerID) {
+            data.customerID = customer;
+        } else if (data.customerID !== customer) {
+            this.notifyService.notify(
+                NotificationType.error,
+                `SLA Error: File customerID "${data.customerID}" does not match current user "${customer}".`
+            );
+            return null;
+        }
+
+        if (data.applications && data.applications.length > 0) {
+            const app = data.applications[0];
+            if (!app.applicationID) {
+                app.applicationID = currentApplication._id.$oid;
+            } else if (app.applicationID !== currentApplication._id.$oid) {
+                this.notifyService.notify(
+                    NotificationType.error,
+                    `SLA Error: File applicationID "${app.applicationID}" does not match current application "${currentApplication._id.$oid}".`
+                );
+                return null;
+            }
+        }
+        return data;
     }
 }

--- a/src/app/shared/modules/helper/sla-parser.service.ts
+++ b/src/app/shared/modules/helper/sla-parser.service.ts
@@ -1,0 +1,56 @@
+import { Injectable } from '@angular/core';
+
+export interface ParsedSlaResult {
+    type: 'v2' | 'v1_microservices';
+    data: any; 
+    appName?: string; 
+}
+
+@Injectable({
+    providedIn: 'root',
+})
+export class SlaParserService {
+    constructor() {}
+
+    /**
+     * Parses the SLA JSON.
+     * Supports both legacy Dashboard format (v1) and new API/CLI format (v2).
+     *
+     * @param data The JSON object loaded from the file
+     * @param currentAppName (Optional) The name of the current application to validate against.
+     *                       If provided, it will be checked against the value in v2 SLAs.
+     */
+    parse(data: any, currentAppName?: string): ParsedSlaResult {
+        if (data.applications && Array.isArray(data.applications) && data.applications.length > 0) {
+            const app = data.applications[0];
+
+            // validate vpplication name consistency
+            if (currentAppName && app.application_name !== currentAppName) {
+                throw new Error(
+                    `SLA Error: The file belongs to application "${app.application_name}", but you are currently editing "${currentAppName}".`,
+                );
+            }
+
+            if (!app.microservices) {
+                throw new Error('SLA Error: Application descriptor found, but no microservices list is present.');
+            }
+
+            return {
+                type: 'v2',
+                data: data,
+                appName: app.application_name,
+            };
+        }
+
+        // legacy format where root key is 'microservices'
+        if (data.microservices && Array.isArray(data.microservices)) {
+            return {
+                type: 'v1_microservices',
+                data: data.microservices,
+            };
+        }
+
+        // invalid format
+        throw new Error('Invalid SLA format: Could not find "applications" or "microservices" properties.');
+    }
+}


### PR DESCRIPTION
This PR fixes #61 by introducing a dedicated SlaParserService to support both legacy (v1) and CLI/API (v2) SLA formats. It also improves the UX by adding a "Select File" button and an in-browser JSON editor to review/modify the payload before uploading.

<img width="1857" height="887" alt="image" src="https://github.com/user-attachments/assets/3a8f4f10-1ef8-4e44-b460-cf7e65b82b54" />
