### PR TITLE
Added Cluster List Constraints to Dashboard

### DIFF
--- a/src/app/control/sla-form/components/constraints/components/cluster-constraints/cluster-constraints.component.html
+++ b/src/app/control/sla-form/components/constraints/components/cluster-constraints/cluster-constraints.component.html
@@ -4,10 +4,11 @@
             <nb-form-field>
                 <label class="label">Cluster</label>
                 <nb-select
+                    multiple
                     fullWidth
                     placeholder="Cluster"
                     formControlName="cluster"
-                    nbTooltip="Specifies the cluster in which the constraint is in effect"
+                    nbTooltip="Specifies the cluster(s) in which the constraint is in effect"
                 >
                     <nb-option *ngFor="let option of clusterOptions" [value]="option">{{ option }}</nb-option>
                 </nb-select>
@@ -18,6 +19,12 @@
                 <label class="label">Node</label>
                 <input fullWidth placeholder="Node" nbInput formControlName="node" nbTooltip="Node" />
             </nb-form-field>
+        </div>
+    </div>
+
+    <div *ngIf="showNodeWarning" class="w3-row w3-padding">
+        <div class = "note-box">
+            <small><strong>Note:</strong> You can choose a target node only if you specify a single target cluster.</small>
         </div>
     </div>
 </form>

--- a/src/app/control/sla-form/components/constraints/components/cluster-constraints/cluster-constraints.component.scss
+++ b/src/app/control/sla-form/components/constraints/components/cluster-constraints/cluster-constraints.component.scss
@@ -2,3 +2,13 @@
     display: flex;
     align-items: center;
 }
+
+.note-box {
+    background-color: #eebd53;
+    color: #4e4022;
+    padding: 10px;
+    border-radius: 4px;
+    width: 100%;
+    margin-top: 5px;
+    font-size: 1.2em;
+}

--- a/src/app/control/sla-form/components/constraints/components/cluster-constraints/cluster-constraints.component.ts
+++ b/src/app/control/sla-form/components/constraints/components/cluster-constraints/cluster-constraints.component.ts
@@ -23,16 +23,35 @@ export class ClusterConstraintsComponent implements OnInit {
         this.apiService.getClusters().subscribe((x) => {
             console.log(x);
             this.clusterOptions = x.map((cluster: any) => cluster.cluster_name);
+            this.clusterOptions.push('I am a fake cluster');
+            this.clusterOptions.push('Another fake cluster');
             console.log(this.clusterOptions);
         });
 
         this.parentForm = this.parent.form;
-        this.parentForm.addControl(
-            this.formGroupName,
-            this.fb.group({
-                node: [''],
-                cluster: [],
-            }),
-        );
+        
+        const constraintsGroup = this.fb.group({
+            node: [''],
+            cluster: [],
+        });
+
+        this.parentForm.addControl(this.formGroupName, constraintsGroup);
+
+        constraintsGroup.get('cluster')?.valueChanges.subscribe((selectedClusters: string[]) => {
+            const nodeControl = constraintsGroup.get('node');
+
+            if (Array.isArray(selectedClusters) && selectedClusters.length > 1) {
+                nodeControl?.setValue('');    
+                nodeControl?.disable();    
+            } else {
+                nodeControl?.enable();     
+            }
+        });
+
+    }
+
+    get showNodeWarning(): boolean {
+        const clusters = this.parentForm.get(this.formGroupName)?.get('cluster')?.value;
+        return Array.isArray(clusters) && clusters.length > 1;
     }
 }

--- a/src/app/control/sla-form/components/constraints/components/cluster-constraints/cluster-constraints.component.ts
+++ b/src/app/control/sla-form/components/constraints/components/cluster-constraints/cluster-constraints.component.ts
@@ -23,8 +23,6 @@ export class ClusterConstraintsComponent implements OnInit {
         this.apiService.getClusters().subscribe((x) => {
             console.log(x);
             this.clusterOptions = x.map((cluster: any) => cluster.cluster_name);
-            this.clusterOptions.push('I am a fake cluster');
-            this.clusterOptions.push('Another fake cluster');
             console.log(this.clusterOptions);
         });
 

--- a/src/app/control/sla-form/components/constraints/constraints.component.ts
+++ b/src/app/control/sla-form/components/constraints/constraints.component.ts
@@ -66,6 +66,7 @@ export class ConstraintsComponent extends SubComponent implements OnInit {
             convergence_time: 0,
             location: '',
             node: '',
+            allowed: [],
             rigidness: 0,
             threshold: 0,
             type,
@@ -109,7 +110,27 @@ export class ConstraintsComponent extends SubComponent implements OnInit {
             console.log(k);
             console.log(constrains[k]);
             const name = this.getConstraintsName(k);
-            if (name) {
+            
+            if (name === ConstraintType.DIRECT) {
+                const data = constrains[k];
+
+                //only one cluster with specific node
+                if (data.node && data.node.trim() !== '') {
+                    result.push({
+                        type: ConstraintType.DIRECT,
+                        cluster: Array.isArray(data.cluster) ? data.cluster[0] : data.cluster, 
+                        node: data.node
+                    });
+                } 
+                // cluster list
+                else if (data.cluster && data.cluster.length > 0) {
+                    result.push({
+                        type: ConstraintType.CLUSTERS, 
+                        allowed: Array.isArray(data.cluster) ? data.cluster : [data.cluster] 
+                    });
+                }
+            } 
+            else if (name) {
                 result.push({
                     type: name,
                     ...constrains[k],

--- a/src/app/root/enums/constraint.ts
+++ b/src/app/root/enums/constraint.ts
@@ -2,4 +2,5 @@ export enum ConstraintType {
     LATENCY = 'latency',
     GEO = 'geo',
     DIRECT = 'direct',
+    CLUSTERS = 'clusters',
 }

--- a/src/app/root/interfaces/service.ts
+++ b/src/app/root/interfaces/service.ts
@@ -56,6 +56,7 @@ export interface IConstraints {
     cluster: string;
     node: string;
     location: string;
+    allowed?: string[];
     threshold: 0;
     rigidness: 0;
     convergence_time: 0;


### PR DESCRIPTION
This PR refers to this [issue](https://github.com/oakestra/dashboard/issues/56) adding the new constraint to add multiple clusters in the Dashboard.

<img width="1497" height="458" alt="image" src="https://github.com/user-attachments/assets/b3561586-3546-4823-a3ad-992fc1b524d3" />

If more than one cluster is selected the Node section becomes disabled:
<img width="1491" height="282" alt="image" src="https://github.com/user-attachments/assets/1fd349a2-ebf9-42f3-b6e2-d5f342dcd253" />

If multiple clusters are selected (or only one without specifying the Node), the type "clusters" is used in the SLA. However, if there's only one cluster with a specific Node, it uses type "direct".
