### PR TITLE
fix: silent error swallowing in REST error handling

### DIFF
--- a/src/app/shared/modules/auth/user.service.ts
+++ b/src/app/shared/modules/auth/user.service.ts
@@ -173,8 +173,7 @@ export class UserService {
         if (this.checkIfTokenExists(key)) {
             return localStorage.getItem(key) ?? '';
         } else {
-            throwError('No refresh token found');
-            return '';
+            throw new Error('No refresh token found');
         }
     }
 
@@ -220,16 +219,13 @@ export class UserService {
                 if (!this.isTokenExpired(key)) {
                     return key;
                 } else {
-                    throwError('The token is already expired');
-                    return '';
+                    throw new Error('The token is already expired');
                 }
             } else {
-                throwError('No cluster token found');
-                return '';
+                throw new Error('No cluster token found');
             }
         }
-        throwError('Session expired, please log in again');
-        return '';
+        throw new Error('Session expired, please log in again');
     }
 
     addCluster(cluster_info: any): Observable<string> {

--- a/src/app/shared/util/rest.service.ts
+++ b/src/app/shared/util/rest.service.ts
@@ -32,7 +32,7 @@ export class RestService {
                 return this.userService.renewToken().pipe(mergeMap(() => request));
             } else {
                 this.userService.redirectToLogin();
-                return throwError('Session expired!');
+                return throwError(() => new Error('Session expired!'));
             }
         }
     }

--- a/src/app/shared/util/rest.service.ts
+++ b/src/app/shared/util/rest.service.ts
@@ -37,6 +37,15 @@ export class RestService {
         }
     }
 
+    private handleError(error: any): Observable<never> {
+        const message =
+            (typeof error?.error === 'string' ? error.error : error?.error?.message) ||
+            error?.message ||
+            'Server error';
+        this.notificationService.notify(NotificationType.error, message);
+        return throwError(() => new Error(message));
+    }
+
     public doGETRequest<T>(url: string): Observable<T> {
         const request = this.http.get(this.baseURL + url, this.requestOptions).pipe(
             map((res: any) => {
@@ -45,10 +54,7 @@ export class RestService {
                 }
                 return res;
             }),
-            catchError((error) => {
-                this.notificationService.notify(NotificationType.error, error.error);
-                return throwError(error || 'Server error');
-            }),
+            catchError((error) => this.handleError(error)),
         );
         return this.doRequest(request);
     }
@@ -59,18 +65,13 @@ export class RestService {
         };
         const request = this.http.delete(this.baseURL + url, requestOptions).pipe(
             map((res: any) => {
-                if (res == null) {
-                    throwError('no data');
-                } else if (typeof res === 'string') {
+                // A successful DELETE commonly responds with 204 No Content, so a null body here is not an error.
+                if (typeof res === 'string') {
                     return JSON.parse(res);
-                } else {
-                    return res;
                 }
+                return res;
             }),
-            catchError((error) => {
-                this.notificationService.notify(NotificationType.error, error.error.message);
-                return throwError(error || 'Server error');
-            }),
+            catchError((error) => this.handleError(error)),
         );
         return this.doRequest(request);
     }
@@ -79,28 +80,21 @@ export class RestService {
         const request = this.http.post(this.baseURL + url, object, this.requestOptions).pipe(
             map((res: any) => {
                 if (res == null) {
-                    throwError('no data');
-                    return null;
+                    throw new Error('No data received from server');
                 } else if (typeof res === 'string') {
                     return JSON.parse(res);
                 } else {
                     return res;
                 }
             }),
-            catchError((error) => {
-                this.notificationService.notify(NotificationType.error, error.error.message);
-                return throwError(error || 'Server error');
-            }),
+            catchError((error) => this.handleError(error)),
         );
         return this.doRequest(request);
     }
 
     public doPUTRequest<T>(url: string, object: any): Observable<T> {
         const request = this.http.put<T>(this.baseURL + url, object, this.requestOptions).pipe(
-            catchError((error) => {
-                this.notificationService.notify(NotificationType.error, error.error.message);
-                return throwError(error || 'Server error');
-            }),
+            catchError((error) => this.handleError(error)),
         );
         return this.doRequest(request);
     }
@@ -109,27 +103,20 @@ export class RestService {
         return this.http.post(this.baseURL + url, object, this.requestOptions).pipe(
             map((res: any) => {
                 if (res == null) {
-                    throwError('no data');
-                    return null;
+                    throw new Error('No data received from server');
                 } else if (typeof res === 'string') {
                     return JSON.parse(res);
                 } else {
                     return res;
                 }
             }),
-            catchError((error) => {
-                this.notificationService.notify(NotificationType.error, error.error.message);
-                return throwError(error || 'Server error');
-            }),
+            catchError((error) => this.handleError(error)),
         );
     }
 
     public doPUTPublicRequest<T>(url: string, object: any): Observable<T> {
         return this.http.put<T>(this.baseURL + url, object, this.requestOptions).pipe(
-            catchError((error) => {
-                this.notificationService.notify(NotificationType.error, error.error.message);
-                return throwError(error || 'Server error');
-            }),
+            catchError((error) => this.handleError(error)),
         );
     }
 }


### PR DESCRIPTION
RestService and UserService called throwError() as if it were a synchronous
throw, but the resulting Observable was never returned or subscribed to, so
failed requests and missing tokens were silently treated as success.

- Consolidated the duplicated catchError blocks in RestService into a single
  handleError() helper that correctly extracts a message from both plain-text
  and object-shaped error bodies, and actually throws an Error so downstream
  NgRx effects reading error.message get real data instead of undefined.
- Fixed map() blocks in doPOSTRequest/doPOSTPublicRequest where throwError('no
  data') was called but discarded, silently returning null instead of erroring.
- Removed the same check from doDELRequest entirely, since a 204 No Content
  response is the expected outcome for a successful delete and no caller reads
  the DELETE response body.
- getJWTTokenRaw() and getClusterKey() in UserService now throw a real Error
  instead of calling throwError() (a no-op outside an Observable context) and
  silently returning an empty string.