### PR TITLE
fix: RxJS subscription leaks across several components

### DIFF
--- a/src/app/@theme/components/header/header.component.ts
+++ b/src/app/@theme/components/header/header.component.ts
@@ -46,6 +46,7 @@ export class HeaderComponent implements OnInit, OnDestroy {
             .pipe(
                 filter(({ tag }) => tag === 'userMenu'),
                 map(({ item: { title } }) => title),
+                takeUntil(this.destroy$),
             )
             .subscribe((title) => {
                 switch (title) {

--- a/src/app/control/application-dashboard/applications.component.ts
+++ b/src/app/control/application-dashboard/applications.component.ts
@@ -1,6 +1,7 @@
-import { Component, Input } from '@angular/core';
+import { Component, Input, OnDestroy, OnInit } from '@angular/core';
 import { Router } from '@angular/router';
-import { Observable } from 'rxjs';
+import { Observable, Subject } from 'rxjs';
+import { take, takeUntil } from 'rxjs/operators';
 import { select, Store } from '@ngrx/store';
 import { NbDialogService } from '@nebular/theme';
 import { IId } from '../../root/interfaces/id';
@@ -27,12 +28,14 @@ import { DialogAddApplicationView } from './dialogs/add-appllication/dialogAddAp
     templateUrl: './applications.component.html',
     styleUrls: ['./applications.component.scss'],
 })
-export class ApplicationsComponent {
+export class ApplicationsComponent implements OnInit, OnDestroy {
     @Input() userID: string;
     DialogAction = DialogAction;
     activeAppId: IId;
 
     public apps$: Observable<IApplication[]> = this.store.pipe(select(selectApplications));
+
+    private destroy$ = new Subject<void>();
 
     constructor(
         public dialog: NbDialogService,
@@ -44,19 +47,26 @@ export class ApplicationsComponent {
     ) {}
 
     ngOnInit(): void {
-        this.store.select(selectCurrentUser).subscribe((u) => {
-            this.userID = u._id.$oid;
-            this.store.dispatch(getApplication({ id: this.userID }));
-        });
+        this.store
+            .select(selectCurrentUser)
+            .pipe(takeUntil(this.destroy$))
+            .subscribe((u) => {
+                this.userID = u._id.$oid;
+                this.store.dispatch(getApplication({ id: this.userID }));
+            });
 
-        this.apps$.subscribe((apps) => {
-            console.log(apps);
+        this.apps$.pipe(takeUntil(this.destroy$)).subscribe((apps) => {
             const active = apps.filter((a) => a._id.$oid === sessionStorage.getItem('id'))[0];
             if (active) {
                 this.store.dispatch(setCurrentApplication({ application: active }));
                 this.activeAppId = active._id;
             }
         });
+    }
+
+    ngOnDestroy(): void {
+        this.destroy$.next();
+        this.destroy$.complete();
     }
 
     openDialogApp(action: DialogAction, app: IApplication | undefined) {
@@ -83,7 +93,7 @@ export class ApplicationsComponent {
                 this.store.dispatch(updateApplication({ application: result.data }));
             } else if (result.event === DialogAction.DELETE) {
                 //get different app form apps$ to set as current
-                this.apps$.subscribe((app) => {
+                this.apps$.pipe(take(1)).subscribe((app) => {
                     var activeApps = app.filter((a) => a._id.$oid !== result.data._id.$oid)
                     if (activeApps.length > 0) {
                         this.store.dispatch(setCurrentApplication({ application: activeApps[0] }));

--- a/src/app/control/service-dashboard/components/instance-detail/chart-cpu-line.component.ts
+++ b/src/app/control/service-dashboard/components/instance-detail/chart-cpu-line.component.ts
@@ -1,6 +1,7 @@
 import { Component, Input, OnDestroy, OnInit } from '@angular/core';
 import { NbColorHelper, NbThemeService } from '@nebular/theme';
-import { Observable } from 'rxjs';
+import { Observable, Subject } from 'rxjs';
+import { takeUntil } from 'rxjs/operators';
 import Chart from 'chart.js/auto';
 import { IHistoricalData, IInstance } from '../../../../root/interfaces/instance';
 
@@ -14,12 +15,13 @@ export class ChartCpuLineComponent implements OnDestroy, OnInit {
     options: any;
     themeSubscription: any;
     private cpuChart: Chart;
+    private destroy$ = new Subject<void>();
 
     constructor(private theme: NbThemeService) { }
 
     ngOnInit(): void {
         this.createCharts();
-        this.instance$.subscribe((instance: IInstance) => {
+        this.instance$.pipe(takeUntil(this.destroy$)).subscribe((instance: IInstance) => {
             this.updateCharts(instance);
         });
     }
@@ -113,5 +115,7 @@ export class ChartCpuLineComponent implements OnDestroy, OnInit {
 
     ngOnDestroy(): void {
         this.themeSubscription.unsubscribe();
+        this.destroy$.next();
+        this.destroy$.complete();
     }
 }

--- a/src/app/control/service-dashboard/components/instance-detail/chart-memory-line.component.ts
+++ b/src/app/control/service-dashboard/components/instance-detail/chart-memory-line.component.ts
@@ -1,6 +1,7 @@
 import { Component, Input, OnDestroy, OnInit } from '@angular/core';
 import { NbColorHelper, NbThemeService } from '@nebular/theme';
-import { Observable } from 'rxjs';
+import { Observable, Subject } from 'rxjs';
+import { takeUntil } from 'rxjs/operators';
 import { Chart } from 'chart.js';
 import { IHistoricalData, IInstance } from '../../../../root/interfaces/instance';
 
@@ -14,14 +15,14 @@ export class ChartMemoryLineComponent implements OnDestroy, OnInit {
     options: any;
     themeSubscription: any;
     private memoryChart: Chart;
+    private destroy$ = new Subject<void>();
 
     constructor(private theme: NbThemeService) { }
 
     ngOnInit(): void {
         this.createCharts();
-        this.instance$.subscribe((instance: IInstance) => {
+        this.instance$.pipe(takeUntil(this.destroy$)).subscribe((instance: IInstance) => {
             this.updateCharts(instance);
-            console.log(instance);
         });
     }
 
@@ -114,5 +115,7 @@ export class ChartMemoryLineComponent implements OnDestroy, OnInit {
 
     ngOnDestroy(): void {
         this.themeSubscription.unsubscribe();
+        this.destroy$.next();
+        this.destroy$.complete();
     }
 }

--- a/src/app/control/service-dashboard/components/instance-detail/instance-detail.component.ts
+++ b/src/app/control/service-dashboard/components/instance-detail/instance-detail.component.ts
@@ -49,23 +49,21 @@ export class InstanceDetailComponent implements OnInit, AfterViewInit, OnDestroy
         this.serviceId = this.route.snapshot.paramMap.get('service-id');
         this.instanceId = this.route.snapshot.paramMap.get('instance-id');
 
-        this.services$.subscribe({
+        this.services$.pipe(takeWhile(() => this.alive)).subscribe({
             next: (services: IService[]) => {
                 const s = services.filter((s: IService) => s._id?.$oid === this.serviceId);
                 this.service = s.length === 0 ? null : s[0];
             },
         });
-        console.log(this.instance);
 
         this.refreshData();
         this.timerSubscription = timer(15000, 15000)
             .pipe(takeWhile(() => this.alive))
             .subscribe(() => this.refreshData());
 
-        this.instance.subscribe((i) => {
+        this.instance.pipe(takeWhile(() => this.alive)).subscribe((i) => {
             const location = i.cluster_location.length > 0 ? i.cluster_location : '48.1624064,11.5977288,12';
             this.setLocation(location);
-            console.log(i);
         });
     }
 

--- a/src/app/control/users/users.component.ts
+++ b/src/app/control/users/users.component.ts
@@ -1,9 +1,10 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, OnDestroy, OnInit } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
 import { FormControl } from '@angular/forms';
 import { DatePipe } from '@angular/common';
 import { select, Store } from '@ngrx/store';
-import { Observable } from 'rxjs';
+import { Observable, Subject } from 'rxjs';
+import { takeUntil } from 'rxjs/operators';
 import { NbDialogService } from '@nebular/theme';
 import { ApiService } from '../../shared/modules/api/api.service';
 import { NotificationService } from '../../shared/modules/notification/notification.service';
@@ -21,7 +22,7 @@ import { DialogEditUserView } from './dialogs/edit-user/dialogEditUser';
     templateUrl: './users.component.html',
     styleUrls: ['./users.component.scss'],
 })
-export class UsersComponent implements OnInit {
+export class UsersComponent implements OnInit, OnDestroy {
     DialogAction = DialogAction;
     displayedColumns: string[] = ['name', 'created_at', 'roles', 'symbol'];
     searchedUsers: Array<IUser> = [];
@@ -31,6 +32,9 @@ export class UsersComponent implements OnInit {
     dropdownList: string[] = [];
 
     public users$: Observable<IUser[]> = this.store.pipe(select(selectAllUser));
+
+    private destroy$ = new Subject<void>();
+    private allUsers: IUser[] = [];
 
     constructor(
         private router: Router,
@@ -48,7 +52,16 @@ export class UsersComponent implements OnInit {
         this.loadData();
         const organization_id = this.userService.getOrganization();
         this.store.dispatch(getAllUser({ organization_id }));
-        this.users$.subscribe((x) => console.log(x));
+
+        this.users$.pipe(takeUntil(this.destroy$)).subscribe((u) => {
+            this.allUsers = u;
+            this.applyFilter();
+        });
+    }
+
+    ngOnDestroy(): void {
+        this.destroy$.next();
+        this.destroy$.complete();
     }
 
     loadData(): void {
@@ -74,15 +87,13 @@ export class UsersComponent implements OnInit {
     }
 
     doFilter($event: any): void {
-        console.log('Filter');
         this.searchText = $event;
-        this.users$.subscribe((u) => {
-            this.searchedUsers = u.filter((user) => this.nameFilter(user) && this.roleFilter(user));
-            console.log(this.searchedUsers);
-        });
-
         this.selectedItems = this.dropdown.value;
-        console.log(this.selectedItems);
+        this.applyFilter();
+    }
+
+    private applyFilter(): void {
+        this.searchedUsers = this.allUsers.filter((user) => this.nameFilter(user) && this.roleFilter(user));
     }
 
     nameFilter(user: IUser): boolean {


### PR DESCRIPTION
Unsubscribe from RxJS observables when components are destroyed to prevent memory leaks. Implemented the standard `takeUntil(destroy$)` pattern across header, applications, chart, instance detail, and users components. Also removed debug console.log statements and refactored one-time subscriptions to use `take(1)` instead of manual cleanup where appropriate.