### PR TITLE
fix: instance detail map coordinates and chart data label mismatch

### DIFF
--- a/src/app/control/service-dashboard/components/instance-detail/chart-cpu-line.component.ts
+++ b/src/app/control/service-dashboard/components/instance-detail/chart-cpu-line.component.ts
@@ -84,26 +84,25 @@ export class ChartCpuLineComponent implements OnDestroy, OnInit {
     }
 
     private updateCharts(instance: IInstance): void {
-        let timeLables = instance.cpu_history.map((data: IHistoricalData) => {
+        let sampledHistory: IHistoricalData[];
+        if (instance.cpu_history.length === 100) {
+            sampledHistory = [];
+            for (let i = 0; i < 10; i++) {
+                sampledHistory.push(instance.cpu_history[i * 10]);
+            }
+        } else {
+            sampledHistory = instance.cpu_history.slice(Math.max(instance.cpu_history.length - 10, 0));
+        }
+
+        const timeLables = sampledHistory.map((data: IHistoricalData) => {
             const d = new Date(data.timestamp);
             return `${d.getHours().toString().padStart(2, '0')}:${d.getMinutes().toString().padStart(2, '0')}:${d
                 .getSeconds()
                 .toString()
                 .padStart(2, '0')}`;
         });
+        const cpuData = sampledHistory.map((data) => Number.parseFloat(data.value));
 
-        if (timeLables.length === 100) {
-            const reducedList: any[] = [];
-            for (let i = 0; i < 10; i++) {
-                reducedList.push(timeLables[i * 10]);
-            }
-            timeLables = reducedList;
-        } else {
-            const index = timeLables.length - 1;
-            timeLables = timeLables.slice(index - 10, index);
-        }
-
-        const cpuData = instance.cpu_history.map((data) => Number.parseFloat(data.value));
         this.cpuChart.data.datasets.forEach((dataset) => {
             dataset.data = cpuData;
         });

--- a/src/app/control/service-dashboard/components/instance-detail/chart-memory-line.component.ts
+++ b/src/app/control/service-dashboard/components/instance-detail/chart-memory-line.component.ts
@@ -85,26 +85,25 @@ export class ChartMemoryLineComponent implements OnDestroy, OnInit {
     }
 
     private updateCharts(instance: IInstance): void {
-        let timeLables = instance.memory_history.map((data: IHistoricalData) => {
+        let sampledHistory: IHistoricalData[];
+        if (instance.memory_history.length === 100) {
+            sampledHistory = [];
+            for (let i = 0; i < 10; i++) {
+                sampledHistory.push(instance.memory_history[i * 10]);
+            }
+        } else {
+            sampledHistory = instance.memory_history.slice(Math.max(instance.memory_history.length - 10, 0));
+        }
+
+        const timeLables = sampledHistory.map((data: IHistoricalData) => {
             const d = new Date(data.timestamp);
             return `${d.getHours().toString().padStart(2, '0')}:${d.getMinutes().toString().padStart(2, '0')}:${d
                 .getSeconds()
                 .toString()
                 .padStart(2, '0')}`;
         });
+        const memoryData = sampledHistory.map((data) => Number.parseFloat(data.value) / 1000000);
 
-        if (timeLables.length === 100) {
-            const reducedList: any[] = [];
-            for (let i = 0; i < 10; i++) {
-                reducedList.push(timeLables[i * 10]);
-            }
-            timeLables = reducedList;
-        } else {
-            const index = timeLables.length - 1;
-            timeLables = timeLables.slice(index - 10, index);
-        }
-
-        const memoryData = instance.memory_history.map((data) => Number.parseFloat(data.value) / 1000000);
         this.memoryChart.data.datasets.forEach((dataset) => {
             dataset.data = memoryData;
         });

--- a/src/app/control/service-dashboard/components/instance-detail/instance-detail.component.ts
+++ b/src/app/control/service-dashboard/components/instance-detail/instance-detail.component.ts
@@ -70,13 +70,13 @@ export class InstanceDetailComponent implements OnInit, AfterViewInit, OnDestroy
     }
 
     ngAfterViewInit() {
-        const map = L.map('map').setView([this.longitude, this.latitude], 14);
+        const map = L.map('map').setView([this.latitude, this.longitude], 14);
 
         L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
             attribution: '&copy; OpenStreetMap contributors',
         }).addTo(map);
 
-        const circle = L.circle([this.longitude, this.latitude], {
+        const circle = L.circle([this.latitude, this.longitude], {
             color: 'blue',
             fillColor: 'lightblue',
             fillOpacity: 0.5,
@@ -95,12 +95,10 @@ export class InstanceDetailComponent implements OnInit, AfterViewInit, OnDestroy
             /^[-+]?([1-8]?\d(\.\d+)?|90(\.0+)?),\s*[-+]?(180(\.0+)?|((1[0-7]\d)|([1-9]?\d))(\.\d+)?),\s*([-+]?(?:\d+)(?:\.\d+)?)$/;
 
         if (regex.test(locationString)) {
-            console.log('Test');
             const array = locationString.split(',');
-            this.longitude = parseFloat(array[0]);
-            this.latitude = parseFloat(array[1]);
+            this.latitude = parseFloat(array[0]);
+            this.longitude = parseFloat(array[1]);
             this.radius = parseFloat(array[2]);
-            console.log(this.radius);
         } else {
             this.textLocation = locationString;
         }


### PR DESCRIPTION
Fixes two related issues in the instance detail view: 

(1) chart data points and time labels were becoming misaligned when reducing sample size, since labels were reduced separately from data - now both are sampled from the same subset of history

 (2) latitude and longitude were reversed when initializing the Leaflet map and circle, and during location string parsing. See https://leafletjs.com/reference.html#circle for example 

Also removes unnecessary console.log calls along the line :) 