### PR TITLE
fix: delete-refresh race condition and duplicate organization request for logging

### DIFF
--- a/src/app/control/service-dashboard/components/service-item/service-item.component.ts
+++ b/src/app/control/service-dashboard/components/service-item/service-item.component.ts
@@ -3,14 +3,13 @@ import { Router } from '@angular/router';
 import { Store } from '@ngrx/store';
 import { NbDialogService, NbMenuBag, NbMenuService } from '@nebular/theme';
 import { Subscription, tap } from 'rxjs';
-import { filter, map } from 'rxjs/operators';
+import { filter, finalize, map } from 'rxjs/operators';
 import { IService } from '../../../../root/interfaces/service';
 import { ApiService } from '../../../../shared/modules/api/api.service';
 import { appReducer, deleteService, getServices } from '../../../../root/store';
 import { IInstance } from '../../../../root/interfaces/instance';
 import { Subject } from 'rxjs';
 import { ConfigDownloadService } from '../../../../shared/modules/helper/config-download.service';
-import { Observable } from 'tinymce';
 
 @Component({
     selector: 'app-service-item',
@@ -87,9 +86,12 @@ export class ServiceItemComponent implements OnInit, OnDestroy {
     deleteInstance(service: IService, instance: IInstance) {
         this.showSpinner = true;
         setTimeout(() => {
-            this.api.deleteInstance(service, instance).subscribe();
-            this.store.dispatch(getServices({ appId: this.appId }));
-            this.showSpinner = false;
+            this.api
+                .deleteInstance(service, instance)
+                .pipe(finalize(() => (this.showSpinner = false)))
+                .subscribe(() => {
+                    this.store.dispatch(getServices({ appId: this.appId }));
+                });
         }, 5000);
     }
 

--- a/src/app/shared/modules/api/api.service.ts
+++ b/src/app/shared/modules/api/api.service.ts
@@ -144,7 +144,6 @@ export class ApiService extends RestService {
     }
 
     getOrganization(): Observable<IOrganization[]> {
-        this.doGETRequest('/organization/').subscribe((x) => console.log(x));
         return this.doGETRequest('/organization/');
     }
 


### PR DESCRIPTION
Fixed a race condition in the service instance deletion flow where the loading spinner would be hidden and the services list would be refreshed before the delete API request completed. 

Now uses the `finalize` operator to ensure the spinner stays visible until the deletion completes, and the services list is refreshed only after a successful deletion. Also removed a debug console.log statement from the getOrganization method.