### PR TITLE
ci: add testing setup

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,31 @@
+name: Test
+
+on:
+  push:
+    branches:
+      - main
+      - develop
+  pull_request:
+    branches:
+      - main
+      - develop
+
+jobs:
+  run-tests:
+    name: Run unit tests
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out Git repository
+        uses: actions/checkout@v3
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18
+
+      - name: Install Node.js dependencies
+        run: npm ci
+
+      - name: Run unit tests
+        run: npx ng test --watch=false --browsers=ChromeHeadlessCI

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,10 +17,10 @@ jobs:
 
     steps:
       - name: Check out Git repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v7
 
       - name: Set up Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v6
         with:
           node-version: 18
 

--- a/angular.json
+++ b/angular.json
@@ -98,8 +98,11 @@
                         "tsConfig": "tsconfig.spec.json",
                         "karmaConfig": "karma.conf.js",
                         "assets": ["src/favicon.ico", "src/assets"],
-                        "styles": ["src/styles.css",
-                          "src/app/@theme/styles/styles.scss"
+                        "styles": [
+                            "node_modules/@nebular/theme/styles/prebuilt/default.css",
+                            "src/app/@theme/styles/styles.scss",
+                            "src/styles.scss",
+                            "node_modules/leaflet/dist/leaflet.css"
                         ],
                         "scripts": []
                     }

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -35,6 +35,12 @@ module.exports = function(config) {
         colors: true,
         logLevel: config.LOG_INFO,
         autoWatch: true,
+        customLaunchers: {
+            ChromeHeadlessCI: {
+                base: 'ChromeHeadless',
+                flags: ['--no-sandbox', '--disable-gpu'],
+            },
+        },
         browsers: ['Chrome'],
         singleRun: false,
         restartOnFileChange: true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -58,6 +58,7 @@
         "@angular/compiler-cli": "^15.0.2",
         "@babel/eslint-parser": "^7.19.1",
         "@schematics/angular": "^15.0.2",
+        "@types/jasmine": "~4.3.0",
         "@types/leaflet": "^1.9.0",
         "@types/node": "^18.11.10",
         "@types/uuid": "^9.0.2",
@@ -6533,6 +6534,13 @@
       "dependencies": {
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/jasmine": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/@types/jasmine/-/jasmine-4.3.6.tgz",
+      "integrity": "sha512-3N0FpQTeiWjm+Oo1WUYWguUS7E6JLceiGTriFrG8k5PU7zRLJCzLcWURU3wjMbZGS//a2/LgjsnO3QxIlwxt9g==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/json-schema": {
       "version": "7.0.12",

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "@angular/compiler-cli": "^15.0.2",
     "@babel/eslint-parser": "^7.19.1",
     "@schematics/angular": "^15.0.2",
+    "@types/jasmine": "~4.3.0",
     "@types/leaflet": "^1.9.0",
     "@types/node": "^18.11.10",
     "@types/uuid": "^9.0.2",

--- a/src/app/app-error-handler.spec.ts
+++ b/src/app/app-error-handler.spec.ts
@@ -1,0 +1,13 @@
+import { AppErrorHandler } from './app-error-handler';
+
+describe('AppErrorHandler', () => {
+    it('should log the received error to the console', () => {
+        const handler = new AppErrorHandler();
+        const error = new Error('boom');
+        spyOn(console, 'log');
+
+        handler.handleError(error);
+
+        expect(console.log).toHaveBeenCalledWith(error);
+    });
+});

--- a/src/app/shared/modules/auth/auth.service.spec.ts
+++ b/src/app/shared/modules/auth/auth.service.spec.ts
@@ -1,0 +1,55 @@
+import { of } from 'rxjs';
+import { ApiService } from '../api/api.service';
+import { Role } from '../../../root/enums/roles';
+import { AuthService } from './auth.service';
+import { UserService } from './user.service';
+
+describe('AuthService', () => {
+    let userService: jasmine.SpyObj<UserService>;
+    let api: jasmine.SpyObj<ApiService>;
+    let service: AuthService;
+
+    beforeEach(() => {
+        userService = jasmine.createSpyObj('UserService', ['getUsername']);
+        api = jasmine.createSpyObj('ApiService', ['getAuthorization']);
+        service = new AuthService(userService, api);
+    });
+
+    it('should fetch and cache the roles on the first call', () => {
+        userService.getUsername.and.returnValue('alice');
+        api.getAuthorization.and.returnValue(of({ roles: [Role.APP_Provider] }));
+
+        service.getAuthorization().subscribe((auth) => {
+            expect(auth.roles).toEqual([Role.APP_Provider]);
+        });
+
+        expect(service.roles).toEqual([Role.APP_Provider]);
+        expect(api.getAuthorization).toHaveBeenCalledWith('alice');
+    });
+
+    it('should return the cached roles without calling the API again', () => {
+        userService.getUsername.and.returnValue('alice');
+        api.getAuthorization.and.returnValue(of({ roles: [Role.ADMIN] }));
+
+        service.getAuthorization().subscribe();
+        api.getAuthorization.calls.reset();
+
+        service.getAuthorization().subscribe((auth) => {
+            expect(auth.roles).toEqual([Role.ADMIN]);
+        });
+
+        expect(api.getAuthorization).not.toHaveBeenCalled();
+    });
+
+    it('should forget the cached roles after clear()', () => {
+        userService.getUsername.and.returnValue('alice');
+        api.getAuthorization.and.returnValue(of({ roles: [Role.ADMIN] }));
+        service.getAuthorization().subscribe();
+
+        service.clear();
+
+        expect(service.roles).toBeUndefined();
+        service.getAuthorization().subscribe();
+        expect(api.getAuthorization).toHaveBeenCalledTimes(2);
+    });
+});

--- a/src/app/shared/util/clean-json.service.spec.ts
+++ b/src/app/shared/util/clean-json.service.spec.ts
@@ -1,0 +1,67 @@
+import { CleanJsonService } from './clean-json.service';
+
+describe('CleanJsonService', () => {
+    describe('cleanData', () => {
+        it('should remove empty nested objects from a plain object', () => {
+            const input = { a: 1, b: {}, c: { d: 'x' } };
+
+            const result = CleanJsonService.cleanData(input);
+
+            expect(result).toEqual({ a: 1, c: { d: 'x' } });
+        });
+
+        it('should remove empty nested objects from an array', () => {
+            const input = [{ a: 1 }, {}, { b: 2 }];
+
+            const result = CleanJsonService.cleanData(input);
+
+            expect(result).toEqual([{ a: 1 }, { b: 2 }]);
+        });
+
+        it('should leave primitives and non-empty structures untouched', () => {
+            const input = { a: 1, b: 'text', c: [1, 2, 3] };
+
+            const result = CleanJsonService.cleanData(input);
+
+            expect(result).toEqual({ a: 1, b: 'text', c: [1, 2, 3] });
+        });
+    });
+
+    describe('deleteEmptyValues', () => {
+        it('should return falsy input unchanged', () => {
+            expect(CleanJsonService.deleteEmptyValues(null as any)).toBeNull();
+        });
+
+        it('should delete keys with empty string values', () => {
+            const input = { name: '', port: 8080 };
+
+            const result = CleanJsonService.deleteEmptyValues(input);
+
+            expect(result).toEqual({ port: 8080 });
+        });
+
+        it('should keep the microservices key even when empty', () => {
+            const input: Record<string, any> = { microservices: [] };
+
+            const result = CleanJsonService.deleteEmptyValues(input);
+
+            expect(result).toEqual({ microservices: [] });
+        });
+
+        it('should filter out empty strings from array values', () => {
+            const input = { tags: ['a', '', 'b'] };
+
+            const result = CleanJsonService.deleteEmptyValues(input);
+
+            expect(result).toEqual({ tags: ['a', 'b'] });
+        });
+
+        it('should drop a key entirely when its array becomes empty', () => {
+            const input = { tags: [''] };
+
+            const result = CleanJsonService.deleteEmptyValues(input);
+
+            expect(result).toEqual({});
+        });
+    });
+});

--- a/src/test.ts
+++ b/src/test.ts
@@ -4,23 +4,15 @@ import 'zone.js/testing';
 import { getTestBed } from '@angular/core/testing';
 import { BrowserDynamicTestingModule, platformBrowserDynamicTesting } from '@angular/platform-browser-dynamic/testing';
 
-declare const require: {
-    context(
-        path: string,
-        deep?: boolean,
-        filter?: RegExp,
-    ): {
-        keys(): string[];
-        <T>(id: string): T;
-    };
-};
-
 // First, initialize the Angular testing environment.
 getTestBed().initTestEnvironment(BrowserDynamicTestingModule, platformBrowserDynamicTesting(), {
     teardown: { destroyAfterEach: true },
 });
 
 // Then we find all the tests.
-const context = require.context('./', true, /\.spec\.ts$/);
+const context = (import.meta as any).webpackContext('./', {
+    recursive: true,
+    regExp: /\.spec\.ts$/,
+});
 // And load the modules.
-context.keys().map(context);
+context.keys().forEach(context);


### PR DESCRIPTION
Added GitHub Actions workflow to run unit tests on push and PR events, configured Karma for headless browser testing in CI, and modernized the test setup to use Webpack 5 API. Added initial unit test specs for core services and error handling, plus missing Jasmine type definitions.

Fixes #42 
